### PR TITLE
Clean/JSLint/renaming/refactoring (maintainability)

### DIFF
--- a/slimmage.js
+++ b/slimmage.js
@@ -1,165 +1,210 @@
 /* Slimmage 0.2.2, use with ImageResizer. MIT/Apache2 dual licensed by Imazen */
+/*jslint browser: true, devel: true, bitwise: true, plusplus: true */
+(function (win) {
+  "use strict";
 
-(function (w) { //w==window
-    // Enable strict mode
-    "use strict";
+  var slmg = window.slimmage || {},
+	  log = function () {
+	    if (win.slimmage.verbose && win.console && win.console.log) {
+	      try {
+	        win.console.log.apply(win.console, arguments);
+	      } catch (ignore) { }
+	    }
+	  };
 
-    var s =  window.slimmage || {};
-    /** @expose **/
-    window.slimmage = s;
-    if (s.verbose === undefined) /** @expose **/ s.verbose = true;
-    if (s.tryWebP === undefined) /** @expose **/ s.tryWebP = false;
+  window.slimmage = slmg;
 
-    var log = function(){ if (w.slimmage.verbose && w.console && w.console.log) try {w.console.log.apply(w.console,arguments);}catch(e){}};
-    s.beginWebPTest = function(){
-        if (!s.tryWebP || s._testingWebP) return;
-        s._testingWebP = true;
+  if (slmg.verbose === undefined) {
+    slmg.verbose = false;
+  }
 
-        var WebP=new Image();
-        WebP.onload=WebP.onerror=function(){
-            s.webp = (WebP.height==2);
-        };
-        WebP.src='data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAACyAgCdASoCAAIALmk0mk0iIiIiIgBoSygABc6WWgAA/veff/0PP8bA//LwYAAA';
-    };
-   
-    s.getCssValue = function(target, hyphenProp){
-      var val = typeof(window.getComputedStyle) != "undefined" && window.getComputedStyle(target, null).getPropertyValue(hyphenProp);
-      if (!val && target.currentStyle){
-        val = target.currentStyle[hyphenProp.replace(/([a-z])\-([a-z])/, function(a,b,c){ return b + c.toUpperCase();})] || target.currentStyle[hyphenProp];
-      }
-      return val;
-    };
+  if (slmg.tryWebP === undefined) {
+    slmg.tryWebP = false;
+  }
 
-    s.getCssPixels = function(target, hyphenProp){
-      var val = s.getCssValue(target,hyphenProp);
-
-      //We can return pixels directly, but not other units
-      if (val.slice(-2) == "px") return parseFloat(val.slice(0,-2));
-
-      //Create a temporary sibling div to resolve units into pixels.
-      var temp = document.createElement("div");
-      temp.style.overflow = temp.style.visibility = "hidden"; 
-      target.parentNode.appendChild(temp);  
-      temp.style.width = val;
-      var pixels = temp.offsetWidth;
-      target.parentNode.removeChild(temp);
-      return pixels;
-    };
-
-    s.nodesToArray = function (nodeList) {
-        var array = [];
-        // iterate backwards ensuring that length is an UInt32
-        for (var i = nodeList.length >>> 0; i--;) {
-            array[i] = nodeList[i];
-        }
-        return array;
-    };
-    //Expects virtual, not device pixel width
-    s.adjustImageSrcWithWidth = function (img, originalSrc, width) {
-        var dpr = window.devicePixelRatio || 1;
-        var trueWidth = width * dpr;
-
-        var quality = (dpr > 1.49) ? 90 : 80;
-
-        if (s.webp) quality = dpr > 1.49 ? 65 : 78;
-
-        var maxwidth = Math.min(2048, trueWidth); //Limit size to 2048.
-
-        //Minimize variants for caching improvements; round up to nearest multiple of 160
-        maxwidth = maxwidth - (maxwidth % 160) + 160; //Will limit to 13 variations
-
-        var oldpixels = img.getAttribute("data-pixel-width") | 0;
-
-        if (maxwidth > oldpixels) {
-            //Never request a smaller image once the larger one has already started loading
-            var newSrc = originalSrc.replace(/width=\d+/i, "width=" + maxwidth).replace(/quality=[0-9]+/i,"quality=" + quality);
-            if (s.webp) newSrc = newSrc.replace(/format=[a-z]+/i,"format=webp");
-            img.src =  newSrc; 
-            img.setAttribute("data-pixel-width", maxwidth);
-            log("Slimming: updating " + newSrc)
-        }
-    };
-    s.adjustImageSrc = function (img, originalSrc) {
-        s.adjustImageSrcWithWidth(img, originalSrc, s.getCssPixels(img, "max-width"));
-    };
-
-    s.checkResponsiveImages = function (delay) {
-        if (s.timeoutid > 0) w.clearTimeout(s.timeoutid);
-        s.timeoutid = 0;
-        if (delay && delay > 0) {
-            s.timeoutid = w.setTimeout(s.checkResponsiveImages, delay);
-            return;
-        }
-        var stopwatch = new Date().getTime();
-
-        var newImages = 0;
-        //1. Copy images out of noscript tags, but hide 'src' attribute as data-src
-        var n = s.nodesToArray(w.document.getElementsByTagName("noscript"));
-        for (var i = 0, il = n.length; i < il; i++) {
-            var ns = n[i];
-            if (ns.getAttribute("data-slimmage") !== null) {
-                
-                var div = w.document.createElement('div');
-                var contents = (ns.textContent || ns.innerHTML);
-                if (!contents || contents.replace(/[\s\t\r\n]+/,"").length == 0){
-                    //IE doesn't let us touch noscript, so we have to use attributes.
-                    var img = new Image();
-                    for (var ai = 0; ai < ns.attributes.length; ai++) {
-                        var a = ns.attributes[ai];
-                        if (a && a.specified && a.name.indexOf("data-img-") == 0){
-                            img.setAttribute(a.name.slice(9 - a.name.length),a.value);
-                        }
-                    }
-                    div.appendChild(img);
-                }else{
-                    //noscript isn't part of DOM, so we have to recreate it, unescaping html, src->data-src 
-                    div.innerHTML = contents.replace(/\s+src\s*=\s*(['"])/i, " data-src=$1").
-                        replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
-                }
-                //Clear source values before we add it back to the dom, ensure data-slimmage is set.
-                var childImages = div.getElementsByTagName("img");
-                for (var j = 0, jl = childImages.length; j < jl; j++) {
-                    var ci = childImages[j];
-                    if (ci.src !== null && ci.src.length > 0) {
-                        ci.setAttribute("data-src", ci.src);
-                        ci.src = "";
-                    }
-                    ci.setAttribute("data-slimmage", true);
-                    ns.parentNode.insertBefore(ci, ns);
-                    newImages++;
-                }
-                //2. Remove old noscript tags
-                ns.parentNode.removeChild(ns);
-            }
-        }
-
-        //3. Find images with data-slimmage and run adjustImageSrc.
-        var totalImages = 0;
-        var images = s.nodesToArray(w.document.getElementsByTagName("img"));
-        for (var i = 0, il = images.length; i < il; i++) {
-            if (images[i].getAttribute("data-slimmage") !== null) {
-                var originalSrc = images[i].getAttribute("data-src") || images[i].src;
-                s.adjustImageSrc(images[i], originalSrc);
-                totalImages++;
-            }
-        }
-
-        log("Slimmage: restored " + newImages + " images from noscript tags; sizing " + totalImages + " images. " + (new Date().getTime() - stopwatch) + "ms");
-    };
-
-    var h = s.checkResponsiveImages;
-    // Run on resize and domready (w.load as a fallback)
-    if (w.addEventListener) {
-        w.addEventListener("resize", function () { h(500); }, false);
-        w.addEventListener("DOMContentLoaded", function () {
-            h();
-            // Run once only
-            w.removeEventListener("load", h, false);
-        }, false);
-        w.addEventListener("load", h, false);
-    } else if (w.attachEvent) {
-        w.attachEvent("onload", h);
+  slmg.beginWebPTest = function () {
+    if (!slmg.tryWebP || slmg.testingWebP) {
+      return;
     }
-    //test for webp support
-    s.beginWebPTest();
-}(this));
+    slmg.testingWebP = true;
+
+    var webP = new Image();
+    webP.onload = webP.onerror = function () {
+      slmg.webp = (webP.height === 2);
+    };
+
+    webP.src = 'data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAACyAgCdASoCAAIALmk0mk0iIiIiIgBoSygABc6WWgAA/veff/0PP8bA//LwYAAA';
+  };
+
+  slmg.getCssValue = function (target, hyphenProp) {
+    var currentStyle = typeof (window.getComputedStyle) !== "undefined" && window.getComputedStyle(target, null).getPropertyValue(hyphenProp);
+    if (!currentStyle && target.currentStyle) {
+      currentStyle = target.currentStyle[hyphenProp.replace(/([a-z])\-([a-z])/, function (a, b, c) {
+        return b + c.toUpperCase();
+      })] || target.currentStyle[hyphenProp];
+    }
+    return currentStyle;
+  };
+
+  slmg.getCssPixels = function (target, hyphenProp) {
+    var currentStyle = slmg.getCssValue(target, hyphenProp),
+		temp,
+		offsetWidth;
+
+    //We can return pixels directly, but not other units
+    if (currentStyle.slice(-2) === "px") {
+      return parseFloat(currentStyle.slice(0, -2));
+    }
+
+    //Create a temporary sibling div to resolve units into pixels.
+    temp = document.createElement("div");
+    temp.style.overflow = temp.style.visibility = "hidden";
+    target.parentNode.appendChild(temp);
+    temp.style.width = currentStyle;
+    offsetWidth = temp.offsetWidth;
+    target.parentNode.removeChild(temp);
+    return offsetWidth;
+  };
+
+  slmg.nodesToArray = function (nodeList) {
+    var array = [],
+		i = nodeList.length >>> 0;
+
+    while (i--) {
+      array[i] = nodeList[i];
+    }
+
+    return array;
+  };
+
+  //Expects virtual, not device pixel width
+  slmg.adjustImageSrcWithWidth = function (img, originalSrc, width) {
+    var devicePixelRatio = window.devicePixelRatio || 1,
+		trueWidth = width * devicePixelRatio,
+		quality = (devicePixelRatio > 1.49) ? 90 : 80,
+		maxwidth = Math.min(2048, trueWidth), //Limit size to 2048.
+		oldpixels,
+		newSrc;
+
+    if (slmg.webp) {
+      quality = devicePixelRatio > 1.49 ? 65 : 78;
+    }
+
+    //Minimize variants for caching improvements; round up to nearest multiple of 160
+    maxwidth = maxwidth - (maxwidth % 160) + 160; //Will limit to 13 variations
+
+    oldpixels = img.getAttribute("data-pixel-width") | 0;
+
+    if (maxwidth > oldpixels) {
+      //Never request a smaller image once the larger one has already started loading
+      newSrc = originalSrc.replace(/width=\d+/i, "width=" + maxwidth).replace(/quality=[0-9]+/i, "quality=" + quality);
+      if (slmg.webp) {
+        newSrc = newSrc.replace(/format=[a-z]+/i, "format=webp");
+      }
+      img.src = newSrc;
+      img.setAttribute("data-pixel-width", maxwidth);
+      log("Slimming: updating " + newSrc);
+    }
+  };
+
+  slmg.adjustImageSrc = function (img, originalSrc) {
+    slmg.adjustImageSrcWithWidth(img, originalSrc, slmg.getCssPixels(img, "max-width"));
+  };
+
+  slmg.checkResponsiveImages = function (delay) {
+    var stopwatch = new Date().getTime(),
+		newImages = 0,
+		//1. Copy images out of noscript tags, but hide 'src' attribute as data-src
+		nodeArr = slmg.nodesToArray(win.document.getElementsByTagName("noscript")),
+		nodeAttr,
+		node,
+		i = 0,
+		j = 0,
+		k = 0,
+		arrLength = 0,
+		totalImages,
+		images,
+		div,
+		contents,
+		img,
+		childImages,
+		childImage,
+		originalSrc;
+
+    if (slmg.timeoutid > 0) {
+      win.clearTimeout(slmg.timeoutid);
+    }
+    slmg.timeoutid = 0;
+    if (delay && delay > 0) {
+      slmg.timeoutid = win.setTimeout(slmg.checkResponsiveImages, delay);
+      return;
+    }
+
+    for (i = 0, arrLength = nodeArr.length; i < arrLength; i++) {
+      node = nodeArr[i];
+      if (node.getAttribute("data-slimmage") !== null) {
+
+        div = win.document.createElement('div');
+        contents = (node.textContent || node.innerHTML);
+        if (!contents || contents.replace(/[\s\t\r\n]+/, "").length === 0) {
+          //IE doesn't let us touch noscript, so we have to use attributes.
+          img = new Image();
+          for (k = 0; k < node.attributes.length; k++) {
+            nodeAttr = node.attributes[k];
+            if (nodeAttr && nodeAttr.specified && nodeAttr.name.indexOf("data-img-") === 0) {
+              img.setAttribute(nodeAttr.name.slice(9 - nodeAttr.name.length), nodeAttr.value);
+            }
+          }
+          div.appendChild(img);
+        } else {
+          //noscript isn't part of DOM, so we have to recreate it, unescaping html, src->data-src 
+          div.innerHTML = contents.replace(/\s+src\s*=\s*(['"])/i, " data-src=$1").replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+        }
+        //Clear source values before we add it back to the dom, ensure data-slimmage is set.
+        childImages = div.getElementsByTagName("img");
+        for (j = 0; j < childImages.length; j++) {
+          childImage = childImages[j];
+          if (childImage.src !== null && childImage.src.length > 0) {
+            childImage.setAttribute("data-src", childImage.src);
+            childImage.src = "";
+          }
+          childImage.setAttribute("data-slimmage", true);
+          node.parentNode.insertBefore(childImage, node);
+          newImages++;
+        }
+        //2. Remove old noscript tags
+        node.parentNode.removeChild(node);
+      }
+    }
+
+    //3. Find images with data-slimmage and run adjustImageSrc.
+    totalImages = 0;
+    images = slmg.nodesToArray(win.document.getElementsByTagName("img"));
+    for (i = 0, arrLength = images.length; i < arrLength; i++) {
+      if (images[i].getAttribute("data-slimmage") !== null) {
+        originalSrc = images[i].getAttribute("data-src") || images[i].src;
+        slmg.adjustImageSrc(images[i], originalSrc);
+        totalImages++;
+      }
+    }
+
+    log("Slimmage: restored " + newImages + " images from noscript tags; sizing " + totalImages + " images. " + (new Date().getTime() - stopwatch) + "ms");
+  };
+
+  // Run on resize and domready (w.load as a fallback)
+  if (win.addEventListener) {
+    win.addEventListener("resize", function () {
+      slmg.checkResponsiveImages(500);
+    }, false);
+    win.addEventListener("DOMContentLoaded", function () {
+      slmg.checkResponsiveImages();
+      // Run once only
+      win.removeEventListener("load", slmg.checkResponsiveImages, false);
+    }, false);
+    win.addEventListener("load", slmg.checkResponsiveImages, false);
+  } else if (win.attachEvent) {
+    win.attachEvent("onload", slmg.checkResponsiveImages);
+  }
+  //test for webp support
+  slmg.beginWebPTest();
+}(window));


### PR DESCRIPTION
This isn't the equivalent of a "I R#'d your code" commit, so don't panic.

Most important change here; I've modified the variables so they match their purpose, it's better to be verbose and to be honest makes contributions that little bit simpler if everything isn't just using letters... we have minification for reducing the size of the script before it gets to the user.

Swapped out passing 'this' in for 'window'. Scope confusion.

Added JSLint tags and altered the code to meet the requirements.
(equality usage/formatting etc etc etc etc)

As I say, attempting to increase maintainability and contributions by increasing the readability and adding in the standard.

The only breaking change is I've set the debug (verbose) flag to false by default.
