### PR TITLE
Make the four different quality parameters customizable

### DIFF
--- a/slimmage.js
+++ b/slimmage.js
@@ -59,9 +59,9 @@
         var dpr = window.devicePixelRatio || 1;
         var trueWidth = width * dpr;
 
-        var quality = (dpr > 1.49) ? 90 : 80;
+        var quality = (dpr > 1.49) ? s.defaultHighDprQuality || 90 : s.defaultQuality || 80;
 
-        if (s.webp) quality = dpr > 1.49 ? 65 : 78;
+        if (s.webp) quality = dpr > 1.49 ? s.defaultWebPHighDprQuality || 78 : s.defaultWebPQuality || 65;
 
         var maxwidth = Math.min(2048, trueWidth); //Limit size to 2048.
 


### PR DESCRIPTION
Simple change to make quality settings customizable.

Also, wasnt the previous code reversed:

`var quality = (dpr > 1.49) ? 90 : 80;
if (s.webp) quality = dpr > 1.49 ? 65 : 78;`

for webp it it uses a lower quality for high dpr (65) but for non webp it uses the heigher factor (90)
