### PR TITLE
IE8 Exception Fix

### DIFF
--- a/slimmage.js
+++ b/slimmage.js
@@ -37,6 +37,11 @@
       //We can return pixels directly, but not other units
       if (val.slice(-2) == "px") return parseFloat(val.slice(0,-2));
 
+      // IE 8 will return "none" for max-width when not set.
+      // However, "none" is not a valid value for the "width" style
+      // and will cause an exception.
+      val === "none" && (val = "");
+
       //Create a temporary sibling div to resolve units into pixels.
       var temp = document.createElement("div");
       temp.style.overflow = temp.style.visibility = "hidden"; 


### PR DESCRIPTION
I encountered an issue where IE8 was throwing an exception. Turned out to be related to the "max-width" property returning the value of "none" when it isn't specified.

I can increment a version number and minimize the script, I just don't know which minimizer you use.
