### PR TITLE
Test webp support for lossy/lossless/alpha/animation compression

### DIFF
--- a/slimmage.js
+++ b/slimmage.js
@@ -74,11 +74,6 @@
       //We can return pixels directly, but not other units
       if (val.slice(-2) == "px") return parseFloat(val.slice(0,-2));
 
-      // IE 8 will return "none" for max-width when not set.
-      // However, "none" is not a valid value for the "width" style
-      // and will cause an exception.
-      val === "none" && (val = "");
-
       //Create a temporary sibling div to resolve units into pixels.
       var temp = document.createElement("div");
       temp.style.overflow = temp.style.visibility = "hidden"; 

--- a/slimmage.js
+++ b/slimmage.js
@@ -97,12 +97,11 @@
         var data = {
             webp: s.webp,
             width: width,
-            dpr: window.devicePixelRatio || 1,
-            src: originalSrc
+            dpr: window.devicePixelRatio || 1
         }
         data.requestedWidth = Math.min(2048, data.width * data.dpr), //Limit size to 2048.
         data.quality = (data.dpr > 1.49) ? 80 : 90 //Default quality
-        if (data.webp) data.quality = data.dpr > 1.49 ? 65 : 78;
+        if (s.webp) data.quality = data.dpr > 1.49 ? 65 : 78;
         
         //Minimize variants for caching improvements; round up to nearest multiple of 160
         data.requestedWidth = data.requestedWidth - (data.requestedWidth % 160) + 160; //Will limit to 13 variations
@@ -116,10 +115,10 @@
         if (data.requestedWidth > oldpixels) {
             //Never request a smaller image once the larger one has already started loading
             var newSrc = originalSrc.replace(/width=\d+/i, "width=" + data.requestedWidth).replace(/quality=[0-9]+/i,"quality=" + data.quality);
-            if (data.webp) newSrc = newSrc.replace(/format=[a-z]+/i, "format=webp");
-            img.src = newSrc; 
+            if (s.webp) newSrc = newSrc.replace(/format=[a-z]+/i,"format=webp");
+            img.src =  newSrc; 
             img.setAttribute("data-pixel-width", data.requestedWidth);
-            log("Slimming: updating " + newSrc);
+            log("Slimming: updating " + newSrc)
         }
     };
     s.adjustImageSrc = function (img, originalSrc) {


### PR DESCRIPTION
Added test for all webp compressions, lossy/lossless/alpha/animation. All options in webpFeature array has to return true for enabling webp in browser.

Default usage, full feature check
```javascript
window.slimmage = { 
	webpFeature: [ "lossy", "lossless", "alpha", "animation" ] // full webp support
}
```
Basic feature check, "lossy"
```javascript
window.slimmage = { 
	webpFeature: [ "lossy"] // basic webp support
}
```

credits and more information at: https://developers.google.com/speed/webp/faq#how_can_i_detect_browser_support_using_javascript