### PR TITLE
Set float to none on the temp div

### DIFF
--- a/slimmage.js
+++ b/slimmage.js
@@ -44,6 +44,7 @@
       //Create a temporary sibling div to resolve units into pixels.
       var temp = document.createElement("div");
       temp.style.overflow = temp.style.visibility = "hidden"; 
+      temp.style.cssFloat = "none";
       target.parentNode.appendChild(temp);  
       temp.style.width = val;
       var pixels = temp.offsetWidth;


### PR DESCRIPTION
This fixes a issue in Safari only where if there is a css rule applied to the temporary div that has a float, then the div is created at 0px x 0px and Slimmage doesn't work. Affects both OSX and iOS.