### PR TITLE
Support for CSS background-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ IE11 is [supposed to support the lazyload attribute](https://dvcs.w3.org/hg/webp
 <img lazyload data-slimmage="true" src="http://z.zr.io/ri/1s.jpg?width=100&format=jpg&quality=75" />
 ```
 
+## Sample markup for CSS background-image
+
+**Warning: support for `background-image` is experimental, and has limited browser support.**
+
+The implementation relies on `querySelectorAll`, which is available for IE8+. Styling with `background-size: 100% auto` is a good idea to keep the whole width of the image visible, but note that it works only on IE9+.
+
+```html
+<div data-slimmage-bg="http://z.zr.io/ri/1s.jpg?width=150">
+    <p>Lorem ipsum</p>
+</div>
+
+<style type="text/css">
+    [data-slimmage-bg] {
+        background-size: 100% auto;
+    }
+</style>
+```
 
 ### Notes
 


### PR DESCRIPTION
I needed resizable background-images with dynamic content, so I implemented this. The benefit over a CSS-only solution is that changing an image in code is much easier when you only output one data attribute. I'm not sure if you consider this to be in scope of Slimmage.js, but it made sense to implement it as a feature since Slimmage already has a lot of the required infrastructure.

I have written the code at work, so my employer (HiQ Finland) must be mentioned in the copyright notice. Hopefully this is not an issue.