### PR TITLE
First attempt at a Slimmage Background Image plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Feel free to fork and add links to your HTML filters/helpers here!
 * 0.2.6 - Fix typo causing ‘undefined’ is null error; affects 0.2.4+. 
 * 0.4.0 - Only fire `window.slimmage.readyCallback` on first `checkResponsiveImages()` and when there have been actual modifications to images. Add window.slimmage.webpTimeout to increase likelyhood of webp usage working. Disable verbose output by default. Apply `maxWidth` after `widthStep` instead of before (lowers upper bound from 2080 to 2048). Stop inverting jpeg and webp quality values. Fix IE6/7 setAttribute bug; class value was not copied from noscript element. Add `window.slimmage.enforceCSS` setting; can emulate max-width on IE6/7/8, which lack an implementation.
 * 0.4.1 - Handle resize event on IE 7/8, and increase image size. Fixes “failed to ratched” errors. Improve fluidity of enforceCss when max-width no longer needs to be applied.
+* 0.4.2 - Fix bug causing any parameters starting with w or h to be removed or corrupted. [Contributed by @Jeavon](https://github.com/imazen/slimmage/pull/47) Also fixes [#50](https://github.com/imazen/slimmage/issues/50)
 
 ### Contributor notes
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ If you don’t need those images to be responsive on IE6/7, you can add this cod
     }
 
 
-
 ### Other approaches
 
 * [&lt;picture>](http://responsiveimages.org/) (good if you need art direction)

--- a/slimmage.background.js
+++ b/slimmage.background.js
@@ -1,0 +1,38 @@
+
+(function (w) { //w==window
+    // Enable strict mode
+    "use strict";
+
+    var s =  window['slimmage'];
+	
+	s['adjustBackgroundImageSrc'] = function(elem, previousSrc) {
+        var result = s['getImageInfo'](cssMaxWidth,
+                                       previousSrc,
+                                       elem.getAttribute('data-pixel-width') | 0,
+                                       elem);
+ 
+        if (result){
+          s.setAttr(elem,'data-pixel-width',result['data-pixel-width']);
+		  elem.style.backgroundImage = "url(" + newSrc + ")";
+	      if (!elem.style.backgroundImage) elem.style.backgroundImage = "url(" + originalSrc + ")";
+          log("Slimming: updating " + result['src']);
+		}
+    }
+
+	s['beforeAdjustSrc'] = function(){
+		if (w.document.querySelectorAll) {
+			var i, il, j, jl, k, kl;
+			var totalImages = 0;
+			var images = s.nodesToArray(w.document.querySelectorAll("[data-slimmage-bg]"));
+			for (k = 0, kl = images.length; k < kl; k++) {
+				var previousSrc = images[k].getAttribute("data-slimmage-bg");
+			    if (previousSrc !== null) {
+                    s['adjustBackgroundImageSrc'](images[k], previousSrc);
+                    totalImages++;
+                }
+			}
+		}
+        log("Slimmage: updated " + newImages + " images from background-image styles, checked " + totalImages + " images, changed " + changed.length + ". " + (new Date().getTime() - stopwatch) + "ms");
+	}
+	
+}(this));

--- a/slimmage.js
+++ b/slimmage.js
@@ -1,5 +1,5 @@
 /**
- * @preserve Slimmage 0.4.1, use with ImageResizer. MIT/Apache2 dual licensed by Imazen 
+ * @preserve Slimmage 0.4.2, use with ImageResizer. MIT/Apache2 dual licensed by Imazen 
  */
 
 /* We often use string instead of dot notation to keep 


### PR DESCRIPTION
This is my first attempt at a Background Images plugin based on the Pull Request #37 from dancek.  Slimmage has changed considerably and I hope I got it generally right.

Two problems I'm currently having that I need help with:

1) The var cssMaxWidth = s['getCssPixels'](elem, 'max-width'); call always returns null for me and that causes the getImageInfo to return null as well.  Thus, the fall back to 3000 if falsy.

2) The call to getImageInfo always seems to return an image with a width of 2048.  It's probably my CSS setup somehow, but any help determining the cause would rock. 

Also, is this plugin setup properly?  I didn't have any examples to go off of, so any help with getting it right is appreciated.

Thanks