### PR TITLE
Fix for babel projects (issue with `this` keyword)

### DIFF
--- a/slimmage.js
+++ b/slimmage.js
@@ -10,6 +10,11 @@
     // Enable strict mode
     "use strict";
 
+    // Make sure w is window (For babel-transpiled environments the 'this' keyword may not point to window)
+    if(!w || !w.document) {
+        w = window;
+    }
+
     var s =  window['slimmage'] || {};
     window['slimmage'] = s;
     if (s['verbose'] === undefined) {           s['verbose'] = false;}


### PR DESCRIPTION
I have used Slimmage in previous projects with no issues, but now I tried to use it in a project written in ES2015 and transpiled to older javascript using Babel, and that doesn't work (see fiddle below).

Some funny things happen to the `this` keyword when using Babel, causing it to be undefined - or an object other than window - on the moment it is used in Slimmage, causing it to fail.

The fix proposed is simply to verify if the `w` variable containing the value of `this` points to the window, and change it if it doesn't.

[This fiddle shows the problem](https://jsfiddle.net/239r7boc/3/)

[This fiddle shows the problem fixed](https://jsfiddle.net/239r7boc/4/)
